### PR TITLE
Prevent commits with EITHER warnings or errors

### DIFF
--- a/bin/pomander
+++ b/bin/pomander
@@ -36,7 +36,7 @@ echo -e "${COLOR_MAGENTA}Sniffing your code, hang tight...${COLOR_RESET}"
 
 for FILE in $STAGED_FILES
 do
-  eslint "$FILE"
+  eslint --max-warnings 0 "$FILE"
 
   if [[ "$?" == 0 ]]; then
     echo -e "👍  Passed: $FILE"


### PR DESCRIPTION
## Included in this Pull Request:

- Updated Pomander to prevent commits with either warnings or errors. (Previously, only errors were prevented.)

